### PR TITLE
remove hard coded ids

### DIFF
--- a/python_notebooks/1kg_rna_quantification_service.ipynb
+++ b/python_notebooks/1kg_rna_quantification_service.ipynb
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -47,19 +47,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIl0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIl0\n",
       " dataset_id: WyIxa2dlbm9tZXMiXQ\n",
-      " name: 1kg-rna\n",
+      " name: E-GEUV-1 1000 Genomes RNA Quantification\n",
       "\n"
      ]
     }
    ],
    "source": [
     "counter = 0\n",
-    "for rna_quant_set in c.search_rna_quantification_sets(dataset_id=\"WyIxa2dlbm9tZXMiXQ\"):\n",
+    "dataset_id = c.search_datasets().next().id\n",
+    "for rna_quant_set in c.search_rna_quantification_sets(dataset_id=dataset_id):\n",
     "    if counter > 5:\n",
     "        break\n",
     "    counter += 1\n",
+    "    rna_quantification_set_id = rna_quant_set.id\n",
     "    print(\" id: {}\".format(rna_quant_set.id))\n",
     "    print(\" dataset_id: {}\".format(rna_quant_set.dataset_id))\n",
     "    print(\" name: {}\\n\".format(rna_quant_set.name))"
@@ -75,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -84,14 +86,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " name: 1kg-rna\n",
+      " name: E-GEUV-1 1000 Genomes RNA Quantification\n",
       "\n"
      ]
     }
    ],
    "source": [
     "single_rna_quant_set = c.get_rna_quantification_set(\n",
-    "    rna_quantification_set_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIl0\")\n",
+    "    rna_quantification_set_id=rna_quantification_set_id)\n",
     "print(\" name: {}\\n\".format(single_rna_quant_set.name))"
    ]
   },
@@ -105,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -114,32 +116,42 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "RNA Quantification: hg96\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\n",
-      " description: Kallisto quantification info for HG00096\n",
+      "RNA Quantification: HG00104\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
       "\n",
-      "RNA Quantification: hg96\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\n",
-      " description: Kallisto quantification info for HG00096\n",
+      "RNA Quantification: HG00103\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwMyJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
       "\n",
-      "RNA Quantification: hg96\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\n",
-      " description: Kallisto quantification info for HG00096\n",
+      "RNA Quantification: HG00102\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwMiJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
       "\n",
-      "RNA Quantification: hg99\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5OSJd\n",
-      " description: Kallisto quantification info for HG00099\n",
+      "RNA Quantification: HG00101\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwMSJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
+      "\n",
+      "RNA Quantification: HG00100\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwMCJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
+      "\n",
+      "RNA Quantification: HG00099\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDA5OSJd\n",
+      " description: RNA seq data from lymphoblastoid cell lines in the 1000 Genome Project, http://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/samples/\n",
       "\n"
      ]
     }
    ],
    "source": [
     "counter = 0\n",
+    "rna_quantification_ids = []\n",
     "for rna_quant in c.search_rna_quantifications(\n",
-    "        rna_quantification_set_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIl0\"):\n",
+    "        rna_quantification_set_id=rna_quantification_set_id):\n",
     "    if counter > 5:\n",
     "        break\n",
     "    counter += 1\n",
+    "    rna_quantification_ids.append(rna_quant.id)\n",
     "    print(\"RNA Quantification: {}\".format(rna_quant.name))\n",
     "    print(\" id: {}\".format(rna_quant.id))\n",
     "    print(\" description: {}\\n\".format(rna_quant.description))"
@@ -157,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -166,8 +178,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " name: hg96\n",
-      " read_ids: [u'WyIxa2dlbm9tZXMiLCJyZ3MiLCJIRzAwMDk2IiwiU1JSMDYyNjM0Il0', u'WyIxa2dlbm9tZXMiLCJyZ3MiLCJIRzAwMDk2IiwiU1JSMDYyNjM1Il0', u'WyIxa2dlbm9tZXMiLCJyZ3MiLCJIRzAwMDk2IiwiU1JSMDYyNjQxIl0']\n",
+      " name: HG00104\n",
+      " read_ids: []\n",
       " annotations: [u'WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyJd']\n",
       "\n"
      ]
@@ -175,7 +187,7 @@
    ],
    "source": [
     "single_rna_quant = c.get_rna_quantification(\n",
-    "    rna_quantification_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\")\n",
+    "    rna_quantification_id=rna_quantification_ids[0])\n",
     "print(\" name: {}\".format(single_rna_quant.name))\n",
     "print(\" read_ids: {}\".format(single_rna_quant.read_group_ids))\n",
     "print(\" annotations: {}\\n\".format(single_rna_quant.feature_set_ids))"
@@ -191,7 +203,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -201,45 +213,45 @@
      "output_type": "stream",
      "text": [
       "Expression Level: ENST00000619216.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDYxOTIxNi4xIl0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjMyMTVmN2Q4LTUzZGQtNGQ1NS04MjE1LWRmZTkzMDJhMGQwYiJd\n",
       " feature: \n",
-      " expression: 6.14549 TPM\n",
-      " read_count: 3.34066\n",
+      " expression: 3.17871 TPM\n",
+      " read_count: 1.5\n",
+      " confidence_interval: 0.0 - 0.0\n",
+      "\n",
+      "Expression Level: ENST00000469289.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjVhMGQ2ODhiLTQzMjAtNGNiMy1iZDc5LTQ3OTBiZDYyOTVlOCJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjE5NzkwNCJd\n",
+      " expression: 0.161336 TPM\n",
+      " read_count: 1.13687\n",
       " confidence_interval: 0.0 - 0.0\n",
       "\n",
       "Expression Level: ENST00000461467.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2MTQ2Ny4xIl0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImY5MmUwN2IzLTM4YzAtNGI3MS05YTA2LTQyYjk2ZTA4YWFlNiJd\n",
       " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjE5OTMxMiJd\n",
-      " expression: 0.621227 TPM\n",
-      " read_count: 5.32165\n",
+      " expression: 1.92349 TPM\n",
+      " read_count: 15.7391\n",
       " confidence_interval: 0.0 - 0.0\n",
       "\n",
       "Expression Level: ENST00000466430.5\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2NjQzMC41Il0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjhhYTY5NmMyLWE4MDktNGM0MS1iMmUwLTljNGU3YTRhZTRmZSJd\n",
       " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjM1NDE5MiJd\n",
-      " expression: 0.553376 TPM\n",
-      " read_count: 30.6743\n",
+      " expression: 0.695846 TPM\n",
+      " read_count: 36.7243\n",
       " confidence_interval: 0.0 - 0.0\n",
       "\n",
-      "Expression Level: ENST00000484859.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ4NDg1OS4xIl0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4NzEyMCJd\n",
-      " expression: 0.476131 TPM\n",
-      " read_count: 48.2321\n",
+      "Expression Level: ENST00000495576.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImI5ODhkZTYyLTkxZDctNGUwZC04Zjk5LTYzZWExMGU5NDc2YSJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MTk1MzA0MCJd\n",
+      " expression: 0.00767201 TPM\n",
+      " read_count: 0.178346\n",
       " confidence_interval: 0.0 - 0.0\n",
       "\n",
-      "Expression Level: ENST00000466557.6\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2NjU1Ny42Il0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4ODUyOCJd\n",
-      " expression: 0.645015 TPM\n",
-      " read_count: 15.4836\n",
-      " confidence_interval: 0.0 - 0.0\n",
-      "\n",
-      "Expression Level: ENST00000491962.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ5MTk2Mi4xIl0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MTY4ODkxMiJd\n",
-      " expression: 0.679082 TPM\n",
-      " read_count: 1.37725\n",
+      "Expression Level: ENST00000493797.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImE3OTdlYmRkLWYxZWUtNDY4Mi1hNzlmLTUxZjkwNjVmYjAwNyJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4NjU0NCJd\n",
+      " expression: 0.854432 TPM\n",
+      " read_count: 2.34793\n",
       " confidence_interval: 0.0 - 0.0\n",
       "\n"
      ]
@@ -253,7 +265,7 @@
     "\n",
     "counter = 0\n",
     "for expression in c.search_expression_levels(\n",
-    "        rna_quantification_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\"):\n",
+    "        rna_quantification_id=rna_quantification_ids[0]):\n",
     "    if counter > 5:\n",
     "        break\n",
     "    counter += 1\n",
@@ -275,7 +287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -285,28 +297,28 @@
      "output_type": "stream",
      "text": [
       "Expression Level: ENST00000619216.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDYxOTIxNi4xIl0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjMyMTVmN2Q4LTUzZGQtNGQ1NS04MjE1LWRmZTkzMDJhMGQwYiJd\n",
       " feature: \n",
       "\n",
+      "Expression Level: ENST00000469289.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjVhMGQ2ODhiLTQzMjAtNGNiMy1iZDc5LTQ3OTBiZDYyOTVlOCJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjE5NzkwNCJd\n",
+      "\n",
       "Expression Level: ENST00000461467.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2MTQ2Ny4xIl0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImY5MmUwN2IzLTM4YzAtNGI3MS05YTA2LTQyYjk2ZTA4YWFlNiJd\n",
       " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjE5OTMxMiJd\n",
       "\n",
       "Expression Level: ENST00000466430.5\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2NjQzMC41Il0\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjhhYTY5NmMyLWE4MDktNGM0MS1iMmUwLTljNGU3YTRhZTRmZSJd\n",
       " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjM1NDE5MiJd\n",
       "\n",
-      "Expression Level: ENST00000484859.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ4NDg1OS4xIl0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4NzEyMCJd\n",
+      "Expression Level: ENST00000495576.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImI5ODhkZTYyLTkxZDctNGUwZC04Zjk5LTYzZWExMGU5NDc2YSJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MTk1MzA0MCJd\n",
       "\n",
-      "Expression Level: ENST00000466557.6\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ2NjU1Ny42Il0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4ODUyOCJd\n",
-      "\n",
-      "Expression Level: ENST00000491962.1\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDQ5MTk2Mi4xIl0\n",
-      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MTY4ODkxMiJd\n",
+      "Expression Level: ENST00000493797.1\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImE3OTdlYmRkLWYxZWUtNDY4Mi1hNzlmLTUxZjkwNjVmYjAwNyJd\n",
+      " feature: WyIxa2dlbm9tZXMiLCJnZW5jb2RlX3YyNGxpZnQzNyIsIjE0MDUwOTE3MjA4NjU0NCJd\n",
       "\n"
      ]
     }
@@ -314,7 +326,7 @@
    "source": [
     "counter = 0\n",
     "for expression in c.search_expression_levels(\n",
-    "        rna_quantification_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\", feature_ids=[]):\n",
+    "        rna_quantification_id=rna_quantification_ids[0], feature_ids=[]):\n",
     "    if counter > 5:\n",
     "        break\n",
     "    counter += 1\n",
@@ -332,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -342,28 +354,28 @@
      "output_type": "stream",
      "text": [
       "Expression Level: ENST00000234590.8\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDIzNDU5MC44Il0\n",
-      " expression: 2805.25 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjA3YjM1YjRhLWYwOGQtNDVlMy04ODIyLTc0ODkzYWU5MjI5MSJd\n",
+      " expression: 2138.07 TPM\n",
       "\n",
       "Expression Level: ENST00000374550.7\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDM3NDU1MC43Il0\n",
-      " expression: 3597.17 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImZhNzhkOGM0LTMxYmMtNDkwYi1iMzMxLTRlZDNmOTA2NzAzYyJd\n",
+      " expression: 3041.09 TPM\n",
       "\n",
       "Expression Level: ENST00000396651.7\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDM5NjY1MS43Il0\n",
-      " expression: 2813.83 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjFkOGUwNzBmLThhMzYtNGE1Ni04NjI4LTg1ODY5MWRkOTRlNSJd\n",
+      " expression: 2408.85 TPM\n",
       "\n",
       "Expression Level: ENST00000370321.7\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDM3MDMyMS43Il0\n",
-      " expression: 2234.57 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjBjNjUwODlhLTk2ZmUtNDAwZS1hMWJlLWY3YjZlMTg1MmU5NyJd\n",
+      " expression: 1938.45 TPM\n",
       "\n",
       "Expression Level: ENST00000368567.4\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDM2ODU2Ny40Il0\n",
-      " expression: 8211.31 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsImI1YTlkOGUzLWY2ZDYtNGRhNS05OGI4LTYzOTFiOTZlYzk4OSJd\n",
+      " expression: 6161.73 TPM\n",
       "\n",
       "Expression Level: ENST00000242465.3\n",
-      " id: WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiIsIkVOU1QwMDAwMDI0MjQ2NS4zIl0\n",
-      " expression: 1108.49 TPM\n",
+      " id: WyIxa2dlbm9tZXMiLCJFLUdFVVYtMSAxMDAwIEdlbm9tZXMgUk5BIFF1YW50aWZpY2F0aW9uIiwiSEcwMDEwNCIsIjJjYzgwODViLTVkZDAtNGY4NS05MWVhLTM4OWMxYzM1Y2M5YSJd\n",
+      " expression: 1192.52 TPM\n",
       "\n"
      ]
     }
@@ -371,7 +383,7 @@
    "source": [
     "counter = 0\n",
     "for expression in c.search_expression_levels(\n",
-    "        rna_quantification_id=\"WyIxa2dlbm9tZXMiLCIxa2ctcm5hIiwiaGc5NiJd\", threshold=1000):\n",
+    "        rna_quantification_id=rna_quantification_ids[0], threshold=1000):\n",
     "    if counter > 5:\n",
     "        break\n",
     "    counter += 1\n",


### PR DESCRIPTION
Removes hard coded IDs so notebook examples don't break if the db is modified.