### PR TITLE
g2p: bug fix: import protocol buffer model from new location

### DIFF
--- a/python_notebooks/g2p-example-notebook.ipynb
+++ b/python_notebooks/g2p-example-notebook.ipynb
@@ -350,7 +350,7 @@
     }
    ],
    "source": [
-    "import ga4gh_client.protocol as protocol\n",
+    "import ga4gh.client.protocol as protocol\n",
     "evidence = protocol.EvidenceQuery()\n",
     "evidence.description = \"MEK inhibitors\"\n",
     "    \n",


### PR DESCRIPTION
This PR contains a single 1 line bug fix to correctly load protocol buffer model from correct python package.


As a side note, I used the following docker file to launch and demo latest ga4gh & notebooks from a single container.  Note link between featureset and  phenotypeassociationset - names need to match.


```

FROM python:2.7

#
# Dockerfile-ga4gh-jupyter: container running notebooks and ga4gh server
#

# build: docker build  -t ga4gh-jupyter  -f Dockerfile-ga4gh-jupyter .
# launch: docker run -d --name ga4gh-jupyter  -p 80:8888 -p 8000:8000 -t ga4gh-jupyter
# notebooks can use: ga4gh_endpoint = "http://localhost:8000"


RUN mkdir -p /server
WORKDIR /server

#
# install tools necessary to build python packages
#
RUN apt-get update
RUN apt-get install -y autoconf automake libtool curl make g++ unzip vim

#
# install release version of ga4gh, jupyter and dependencies
#
RUN pip install pip --upgrade  \
  && pip install ga4gh  \
  && pip install jupyter  \
  && pip install bokeh \
  && pip install pandas

#
# get sample data & ontology
#
RUN wget https://github.com/ga4gh/server/releases/download/data/ga4gh-example-data_4.6.tar \
  && tar -xvf ga4gh-example-data_4.6.tar \
  && cd ga4gh-example-data \
  && wget https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so-xp-dec.obo

# notebooks
RUN git clone https://github.com/BD2KGenomics/bioapi-examples.git


#
# create 'cgd' featureset and phenotypeassociationset.  note names need to match
#
#  * ontology needed for featureset
RUN cd /server \
  && ga4gh_repo add-ontology ga4gh-example-data/registry.db  ga4gh-example-data/so-xp-dec.obo -n so-xp
#  * get full monarch RDF
RUN mkdir -p /server/ga4gh-example-data/cgd \
 && cd /server/ga4gh-example-data/cgd \
 && wget https://raw.githubusercontent.com/ohsu-comp-bio/ohsu-server-util/master/cgd-08-09-2016.ttl
#  * update repo
RUN cd /server \
 && ga4gh_repo add-featureset -R  GRCh37-subset -O so-xp  -C PhenotypeAssociationFeatureSet ga4gh-example-data/registry.db  1kg-p3-subset  ga4gh-example-data/cgd   \
 && ga4gh_repo add-phenotypeassociationset ga4gh-example-data/registry.db  1kg-p3-subset  ga4gh-example-data/cgd   -n cgd

#
# Launch ga4gh in background, start jupyter in foreground.
# Note this is for demo only! Ideally, launch in different containers.
# If single container preferred, use supervisord or some other mechanism
#
WORKDIR /server
CMD ga4gh_server -H 0.0.0.0 & jupyter notebook --notebook-dir=/server/bioapi-examples --ip=0.0.0.0

```